### PR TITLE
Allow getting ollama endpoint via an env var

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,7 @@
     op <- options ()
 
     op.pkgmatch <- list ( # nolint
-        pkgmatch.ollama.url = "127.0.0.1:11434"
+        pkgmatch.ollama.url = Sys.getenv("OLLAMA_HOST", "127.0.0.1:11434")
     )
 
     toset <- !(names (op.pkgmatch) %in% names (op))

--- a/vignettes/ollama.Rmd
+++ b/vignettes/ollama.Rmd
@@ -28,7 +28,8 @@ follow one and only one of these sections.
 The "pkgmatch" package presumes by default that the local ollama instance has
 an API endpoint at "127.0.0.1:11434". If this is not the case, alternative
 endpoints can be set using [the `ollama_set_url()`
-function](https://docs.ropensci.org/pkgmatch/reference/ollama_set_url.html).
+function](https://docs.ropensci.org/pkgmatch/reference/ollama_set_url.html) or
+by setting the environment variable `OLLAMA_HOST` before pkgmatch is loaded.
 
 ## Local installation
 


### PR DESCRIPTION
Fix #83 

The env var is not prefixed by PKGMATCH. I don't know what makes more sense.

`OLLAMA_HOST` is used by ollama itself so the nice part is that you could change the endpoint location and make sure pkgmatch picks it up with a single env var.

At the same time, it means it would be more difficult for someone to tell ollama something and pkgmatch something different :thinking:. But is this a realistic use case?

What do you think?

Additionally, I didn't add tests at this stage since the only way I know how is by using callr to start a new session with a specific env var and I don't know how you feel about the new dependency.