### PR TITLE
fix idf extraction in bm25

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title:  Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.4.3.095
+Version: 0.4.3.096
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgmatch
 Title:  Find R Packages Matching Either Descriptions or Other R Packages
-Version: 0.4.3.096
+Version: 0.4.3.097
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),

--- a/R/bm25.R
+++ b/R/bm25.R
@@ -202,7 +202,7 @@ pkgmatch_bm25_from_idf_internal <- function (input, tokens_list, tokens_idf) { #
     n_tarballs <- length (grep ("\\.tar\\.gz$", tok_list_nms))
     if (n_tarballs / length (tokens_list) > 0.9) {
         # All CRAN pkgs have only one underscore between pkg and version:
-        tok_list_nms <- gsub ("\\_.*$", "", tok_list_nms)
+        # tok_list_nms <- gsub ("\\_.*$", "", tok_list_nms)
     }
 
     if (is.character (input)) {

--- a/R/rerank.R
+++ b/R/rerank.R
@@ -9,7 +9,8 @@ pkgmatch_rerank <- function (s, rm_fn_data = TRUE, lm_proportion = 0.5) {
     new_cols <- paste0 (cols, "_rank")
     for (i in seq_along (cols)) {
         # The order of values provides the index that has to be filled with
-        # 1..N values.
+        # 1..N values. Both similarity and BM25 values are higher for more
+        #   similar objects.
         decr <- grepl ("^(bm25|simil)", cols [i])
         o <- order (s [[cols [i]]], decreasing = decr)
         index <- rep (NA_integer_, length (o))

--- a/R/similar-pkgs.R
+++ b/R/similar-pkgs.R
@@ -337,5 +337,5 @@ input_mentions_functions <- function (input) {
 
     stopifnot (length (input) == 1L)
 
-    grepl ("\\sfunction\\s", input, ignore.case = TRUE)
+    grepl ("\\bfunction(s)?\\b", input, ignore.case = TRUE)
 }

--- a/R/similar-pkgs.R
+++ b/R/similar-pkgs.R
@@ -168,6 +168,10 @@ pkgmatch_similar_pkgs <- function (input,
 
     if (is.null (idfs)) {
         idfs <- pkgmatch_load_data (what = "idfs", corpus = corpus)
+        index <- which (!duplicated (names (idfs$token_lists$with_fns)))
+        idfs$token_lists$with_fns <- idfs$token_lists$with_fns [index]
+        index <- which (!duplicated (names (idfs$token_lists$wo_fns)))
+        idfs$token_lists$wo_fns <- idfs$token_lists$wo_fns [index]
     }
     checkmate::assert_list (idfs, len = 2L)
     checkmate::assert_names (

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.4.3.095",
+  "version": "0.4.3.096",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/pkgmatch",
   "issueTracker": "https://github.com/ropensci-review-tools/pkgmatch/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.4.3.096",
+  "version": "0.4.3.097",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
similar_pkgs_from_text joined similarities to bm25, but previous version
removed vers + .tar.gz from package names, so join failed, leaving all
bm25 values as NA -> 0